### PR TITLE
Sort text alphabetically

### DIFF
--- a/searcher.js
+++ b/searcher.js
@@ -481,10 +481,15 @@ var getResultsSortedByField = function (q, frequencies, keySet, options, callbac
     return {id: item}
   }), q, options, function (result) {
     result = result.sort(function (a, b) {
-      if (sortDirection === 'asc') {
-        return a.document[sortKey] - b.document[sortKey]
+      var aVal = a.document[sortKey];
+      var bVal = b.document[sortKey];
+
+      if (aVal === bVal) {
+        return 0;
+      } else if (sortDirection === 'asc') {
+        return aVal < bVal ? -1 : 1;
       } else {
-        return b.document[sortKey] - a.document[sortKey]
+        return aVal < bVal ? 1 : -1;
       }
     }).slice((+q.offset), (+q.offset) + (+q.pageSize))
     return callback(null, result)


### PR DESCRIPTION
There was a bug sorting non-numeric strings because `"foo" - "bar" === NaN`.

This pull request sorts strings alphabetically and numbers numerically. I'll make a pull request to change the tests in search-index in just a sec.
