### PR TITLE
Increase glueDocs concurrency

### DIFF
--- a/searcher.js
+++ b/searcher.js
@@ -600,7 +600,7 @@ var getResultsSortedByTFIDF = function (q, frequencies, options, callbackX) {
 }
 
 var glueDocs = function (hits, q, options, callbackX) {
-  async.mapSeries(hits, function (item, callback) {
+  async.mapLimit(hits, 5, function (item, callback) {
     options.indexes.get('DOCUMENT￮' + item.id + '￮', function (err, value) {
       item.document = value
       if (q.teaser && item.document[q.teaser]) {


### PR DESCRIPTION
In my minimal experimentation, a higher concurrency to fetch the docs gave a bit of a performance boost. I set the limit to 5 concurrent requests instead of a pure `async.map` so it doesn't go crazy with requests.
