### PR TITLE
fix bug when BOOST is used with OR query

### DIFF
--- a/lib/MergeOrConditions.js
+++ b/lib/MergeOrConditions.js
@@ -23,6 +23,9 @@ MergeOrConditions.prototype._flush = function (end) {
     var lastDoc = merged[merged.length - 1]
     if (merged.length === 0 || (cur.id !== lastDoc.id)) {
       merged.push(cur)
+    } else if (cur.id === lastDoc.id && cur.score < lastDoc.score) {
+      // in case a document is duplicated with different score, save the higher score
+      lastDoc.score = cur.score
     }
     return merged
   }, [])

--- a/test/test.js
+++ b/test/test.js
@@ -230,6 +230,31 @@ test('searching with no query returns everything, sorted by ID', function (t) {
   })
 })
 
+test('searching with BOOST and OR query', function (t) {
+  t.plan(1)
+  var results = []
+  sis.search({
+    query: [
+      {
+        AND: {
+          'description': ['collection']
+        },
+        BOOST: 1
+      },
+      {
+        AND: {
+          'name': ['swiss']
+        },
+        BOOST: 5
+      }
+    ]
+  }).on('data', function (doc) {
+    results.push(doc.id)
+  }).on('end', function () {
+    t.looseEqual(results, [ '5', '4', '3', '2', '10', '8' ])
+  })
+})
+
 test('get total results simple query', function (t) {
   t.plan(2)
   sis.totalHits('swiss watch', function (err, totalHits) {


### PR DESCRIPTION
It used to pick the score of one of the OR clause randomly, now it picks the higher score.

It's easy to verify the bug with the attached test. Without these changes, the results of the test case are: [ '3', '2', '10', '5', '8', '4' ], which are incorrect. ID 4 has 'swiss' in the name and should be before ID 8 that doesn't have a match in the name field. 
Also, before these changes, replacing the order of the OR queries yield different results. 