### PR TITLE
Removed leveldown dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "bunyan": "^1.8.1",
     "intersect-arrays-to-stream": "^0.0.3",
-    "leveldown": "^1.5.0",
     "levelup": "^1.3.3",
     "lodash.difference": "^4.5.0",
     "lodash.intersection": "^4.4.0",


### PR DESCRIPTION
leveldown isn't used in this project at all, so it shouldn't be included as it forces native compilation of the module when npm install.