### PR TITLE
Make leveldown an optional dependency (no native build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "bunyan": "^1.8.1",
     "intersect-arrays-to-stream": "^0.0.3",
-    "leveldown": "^1.5.0",
     "levelup": "^1.3.3",
     "lodash.difference": "^4.5.0",
     "lodash.intersection": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "lodash.uniq": "^4.5.0",
     "ngraminator": "0.0.1"
   },
+  "optionalDependencies": {
+    "leveldown": "^1.6.0"
+  },
   "devDependencies": {
     "commitizen": "^2.9.6",
     "search-index-adder": "^0.1.27",


### PR DESCRIPTION
`leveldown` should be an optional dependency so it can be used in projects where native compilation is not possible (when using memdown instead for example).

This change still installs leveldown as usual, but can now be provided with a `--no-optional` flag as well.